### PR TITLE
Update head-block.module.scss

### DIFF
--- a/src/components/home/head-block/head-block.module.scss
+++ b/src/components/home/head-block/head-block.module.scss
@@ -3,7 +3,7 @@
 .banner {
     height: 554px;
     margin: 0 auto 140px;
-    background: url("../../../../public/home/home-banner.jpg") no-repeat;
+    background: url("../../../../public/home/home-banner.jpg") 80% 100% /cover no-repeat;
 }
 
 .title {


### PR DESCRIPTION
Пофиксил промо. Теперь не прилеплено к одной стороне, а на всю ширину сделано. Также при уменьшении ширины окна, промо подстраивается под размер окна.