### PR TITLE
fixed z-index of the modal window component

### DIFF
--- a/src/components/modals/modal/modal.module.scss
+++ b/src/components/modals/modal/modal.module.scss
@@ -2,7 +2,7 @@
 
 .overlay {
     position: fixed;
-    z-index: 2;
+    z-index: 6;
     top: 0;
     right: 0;
     bottom: 0;
@@ -54,3 +54,4 @@
         transform: rotateZ(-45deg);
     }
 }
+


### PR DESCRIPTION
Исправила z-index у модального окна, так как в предыдущей версии модальное окно было перекрыто Шапкой сайта.